### PR TITLE
Fix `check_future_import`.

### DIFF
--- a/libmodernize/__init__.py
+++ b/libmodernize/__init__.py
@@ -12,12 +12,12 @@ def check_future_import(node):
     node = node.children[0]
     # now node is the import_from node
     if not (node.type == syms.import_from and
-            node.type == token.NAME and
+            node.children[1].type == token.NAME and
             node.children[1].value == u'__future__'):
         return set()
     node = node.children[3]
     # now node is the import_as_name[s]
-    print(python_grammar.number2symbol[node.type])
+    # print(python_grammar.number2symbol[node.type])
     if node.type == syms.import_as_names:
         result = set()
         for n in node.children:


### PR DESCRIPTION
Previously the test never evaluated to True because `node.type` could not be simultanously equal to `syms.import_from` (297) and `token.NAME` (1).

In addition, avoid printing unnecessary debugging output.
