### PR TITLE
fix_zip: was importing zip when map() is used

### DIFF
--- a/libmodernize/fixes/fix_zip.py
+++ b/libmodernize/fixes/fix_zip.py
@@ -11,7 +11,7 @@ class FixZip(fixer_base.BaseFix):
     order = "pre"
 
     PATTERN = """
-    power< 'map'
+    power< 'zip'
         trailer< '('
             arglist< any+ >
         ')' >


### PR DESCRIPTION
Fixes https://github.com/mitsuhiko/python-modernize/issues/6
